### PR TITLE
Revert "remove span tag from html title"

### DIFF
--- a/src/Tags.hs
+++ b/src/Tags.hs
@@ -202,7 +202,7 @@ convertSpecificTagsToLinks :: TagsAndAuthors
 convertSpecificTagsToLinks tagsAndAuthors specificTags aTitle = 
     tagsRules specificTags $ \tag pattern -> do
         let nameOfTag = if "категории" `isInfixOf` aTitle then getRussianNameOfCategory tag else tag
-            title = renderHtml $ H.preEscapedToHtml $ aTitle ++ " " ++ nameOfTag
+            title = renderHtml $ H.preEscapedToHtml $ aTitle ++ " <span class=\"tag-in-title\">" ++ nameOfTag ++ "</span>"
         route idRoute
         compile $ do
             posts <- recentFirst =<< loadAll pattern


### PR DESCRIPTION
Reverts ruHaskell/ruhaskell#31

Это сделано сознательно. Да, span в заголовке - это редкость, но я сделал это для стилизации, чтобы идентификатор отличался по цвету от всего заголовка.