### PR TITLE
no extra urlEncode

### DIFF
--- a/src/Tags.hs
+++ b/src/Tags.hs
@@ -20,7 +20,6 @@ module Tags (
 
 import Data.Monoid          (mconcat)
 import Data.List            (intercalate, isInfixOf)
-import Network.HTTP         (urlEncode)
 import Context              (postContext)
 import Misc                 (TagsReader,
                              TagsAndAuthors,

--- a/src/Tags.hs
+++ b/src/Tags.hs
@@ -36,18 +36,16 @@ import qualified Text.Blaze.Html5.Attributes     as A
 import Hakyll
 
 -- Функция извлекает из всех статей значения поля tags и собирает их в кучу.
--- Функция urlEncode необходима для корректного формирования неанглийских меток.
 buildPostsTags :: MonadMetadata m => m Tags
-buildPostsTags = buildTags "posts/**" $ fromCapture "tags/*.html" . urlEncode
+buildPostsTags = buildTags "posts/**" $ fromCapture "tags/*.html"
 
 -- Функция определяет категорию, к которой относится статья.
 buildPostsCategories :: MonadMetadata m => m Tags
 buildPostsCategories = buildCategories "posts/**" $ fromCapture "categories/*.html"
 
 -- Функция извлекает из всех статей значения поля author и собирает их в кучу.
--- Функция urlEncode необходима для корректного формирования неанглийских имён авторов.
 buildPostsAuthors :: MonadMetadata m => m Tags
-buildPostsAuthors = buildTagsWith getNameOfAuthor "posts/**" $ fromCapture "authors/*.html" . urlEncode
+buildPostsAuthors = buildTagsWith getNameOfAuthor "posts/**" $ fromCapture "authors/*.html"
 
 -- Функция отрисовывает тег-ссылку вместе со значком, отражающим количество публикаций,
 -- соответствующих данному тегу. Например, количество статей данного автора.


### PR DESCRIPTION
Чинит #43.

Странно. У меня при локальной сборке Hakyll всё %-кодирует сам, и urlEncode только мешает. Например, "ю" должно в урле превращаться в "%D1%8E", но мы имеем "%25D1%258E" (urlEncode "%" == "%25"). Браузер не может такой урл показать красиво, например.